### PR TITLE
Typo fix for Phenax's description

### DIFF
--- a/Theros Pantheon.json
+++ b/Theros Pantheon.json
@@ -1783,7 +1783,7 @@
       "titles":[
         "God of Deception"],
       "rank":"Deity",
-      "description":"henax is the masked patron of lies and cheats. He is Heliod's ethical antithesis, governing the spheres of gambling, deception, and betrayal. Phenax was once a mortal who was trapped in the Underworld, but he learned how to forsake his identity to prevent Erebos from detecting what he was doing. He crossed back over the Rivers That Ring the World wrapped in the tattered cloak of Athreos, the River Guide, who ushers the dead to their final rest. Hidden by illusion as he was, neither Athreos nor Erebos could find Phenax and bring him back.",
+      "description":"Phenax is the masked patron of lies and cheats. He is Heliod's ethical antithesis, governing the spheres of gambling, deception, and betrayal. Phenax was once a mortal who was trapped in the Underworld, but he learned how to forsake his identity to prevent Erebos from detecting what he was doing. He crossed back over the Rivers That Ring the World wrapped in the tattered cloak of Athreos, the River Guide, who ushers the dead to their final rest. Hidden by illusion as he was, neither Athreos nor Erebos could find Phenax and bring him back.",
       "appearance":"Phenax is a shadowy and mysterious figure. When appearing before mortals, he prefers the form of a willowy humanoid with ashen gray skin, clad in elegant robes. He has also been known to appear in a variety of animal forms, including the shapes of asps, mockingbirds, or rats. Regardless of his shape, a mask forever conceals the blank face of the first Returned.",
       "history":{
         "title":"history",


### PR DESCRIPTION
There was a missing starting "P" for Phenax's name on their description.